### PR TITLE
Remove deprecated deps, and unused imports, & deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.1.1] - 2024-12-03
+
+- Remove unused dependencies.
+
 ## [2.1.0] - 2024-11-05
 
 - TODO: Add release notes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-## [2.1.1] - 2024-12-03
-
-- Remove unused dependencies.
-
 ## [2.1.0] - 2024-11-05
 
 - TODO: Add release notes.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,7 @@
 include: package:flutter_lints/flutter.yaml
+analyzer:
+  errors:
+    constant_identifier_names: ignore
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,28 +1,22 @@
 PODS:
   - Flutter (1.0.0)
-  - uni_links (0.0.1):
-    - Flutter
   - url_launcher_ios (0.0.1):
     - Flutter
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
-  - uni_links (from `.symlinks/plugins/uni_links/ios`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
-  uni_links:
-    :path: ".symlinks/plugins/uni_links/ios"
   url_launcher_ios:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  uni_links: d97da20c7701486ba192624d99bffaaffcfc298a
   url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
 
 PODFILE CHECKSUM: 819463e6a0290f5a72f145ba7cde16e8b6ef0796
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.16.2

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,7 @@
+// ignore_for_file: avoid_print
+
 import 'package:flutter/material.dart';
 import 'package:reclaim_sdk/reclaim.dart';
-import 'package:reclaim_sdk/utils/interfaces.dart';
 import 'package:reclaim_sdk/utils/types.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -8,12 +9,14 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await dotenv.load(fileName: ".env");
-  runApp(MaterialApp(home: ReclaimExample()));
+  runApp(const MaterialApp(home: ReclaimExample()));
 }
 
 class ReclaimExample extends StatefulWidget {
+  const ReclaimExample({super.key});
+
   @override
-  _ReclaimExampleState createState() => _ReclaimExampleState();
+  State<ReclaimExample> createState() => _ReclaimExampleState();
 }
 
 class _ReclaimExampleState extends State<ReclaimExample> {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -278,7 +278,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.1.0"
+    version: "2.1.1"
   sec:
     dependency: transitive
     description:
@@ -364,30 +364,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
-  uni_links:
-    dependency: transitive
-    description:
-      name: uni_links
-      sha256: "051098acfc9e26a9fde03b487bef5d3d228ca8f67693480c6f33fd4fbb8e2b6e"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.5.1"
-  uni_links_platform_interface:
-    dependency: transitive
-    description:
-      name: uni_links_platform_interface
-      sha256: "929cf1a71b59e3b7c2d8a2605a9cf7e0b125b13bc858e55083d88c62722d4507"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
-  uni_links_web:
-    dependency: transitive
-    description:
-      name: uni_links_web
-      sha256: "7539db908e25f67de2438e33cc1020b30ab94e66720b5677ba6763b25f6394df"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.0"
   url_launcher:
     dependency: "direct main"
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -278,7 +278,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.1.0"
   sec:
     dependency: transitive
     description:
@@ -500,6 +500,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.7.3"
+  yaml:
+    dependency: transitive
+    description:
+      name: yaml
+      sha256: "75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.2"
 sdks:
   dart: ">=3.3.0 <4.0.0"
   flutter: ">=3.19.0"

--- a/lib/utils/logger.dart
+++ b/lib/utils/logger.dart
@@ -27,7 +27,7 @@ class ReclaimLogger {
         lineLength: 50,
         colors: true,
         printEmojis: true,
-        printTime: false,
+        dateTimeFormat: logger_package.DateTimeFormat.none,
       ),
     );
   }
@@ -77,7 +77,7 @@ class ReclaimLogger {
   }
 
   void trace(dynamic message, [dynamic error, StackTrace? stackTrace]) {
-    _logger.v(message, error: error, stackTrace: stackTrace);
+    _logger.t(message, error: error, stackTrace: stackTrace);
   }
 }
 

--- a/lib/utils/logger.dart
+++ b/lib/utils/logger.dart
@@ -27,7 +27,7 @@ class ReclaimLogger {
         lineLength: 50,
         colors: true,
         printEmojis: true,
-        dateTimeFormat: logger_package.DateTimeFormat.none,
+        printTime: false,
       ),
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reclaim_sdk
 description: Reclaim SDK provides a way to let your users import data from other websites into your app in a secure, privacy preserving manner using zero knowledge proofs right in your Flutter Application.
-version: 2.1.0
+version: 2.1.1
 homepage: https://www.reclaimprotocol.org/
 repository: https://github.com/reclaimprotocol/reclaim-flutter-sdk.git
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: reclaim_sdk
 description: Reclaim SDK provides a way to let your users import data from other websites into your app in a secure, privacy preserving manner using zero knowledge proofs right in your Flutter Application.
 version: 2.1.0
 homepage: https://www.reclaimprotocol.org/
-repository: https://gitlab.reclaimprotocol.org/reclaim-developer-experience/reclaim-sdk
+repository: https://github.com/reclaimprotocol/reclaim-flutter-sdk.git
 
 scripts:
   update_changelog: dart update_changelog.dart
@@ -17,9 +17,7 @@ dependencies:
     sdk: flutter
   http: ^1.2.1
   logger: ^2.1.0
-  uni_links: ^0.5.1
   url_launcher: ^6.2.5
-  uuid: ^4.3.3
   yaml: ^3.1.2
   web3dart: ^2.7.3
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reclaim_sdk
 description: Reclaim SDK provides a way to let your users import data from other websites into your app in a secure, privacy preserving manner using zero knowledge proofs right in your Flutter Application.
-version: 2.1.1
+version: 2.1.0
 homepage: https://www.reclaimprotocol.org/
 repository: https://github.com/reclaimprotocol/reclaim-flutter-sdk.git
 

--- a/update_version.dart
+++ b/update_version.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_print
+
 import 'dart:io';
 
 void main(List<String> args) {


### PR DESCRIPTION
### Description
Removes unused dependencies and imports and migrates deprecated apis of logger's verbose to trace and logger's date time format from printTime. Also updates the repository url to the current github url.

### Testing (ignore for documentation update)
Not applicable for this change

### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

### Checklist:
- [x] I have read and agree to the [Code of Conduct](https://github.com/reclaimprotocol/.github/blob/main/Code-of-Conduct.md).
- [x] I have signed the [Contributor License Agreement (CLA)](https://github.com/reclaimprotocol/.github/blob/main/CLA.md).
- [x] I have considered the [Security Policy](https://github.com/reclaimprotocol/.github/blob/main/SECURITY.md).
- [x] I have self-reviewed and tested my code.
- [x] I have updated documentation as needed.
- [x] I agree to the [project's custom license](https://github.com/reclaimprotocol/.github/blob/main/LICENSE).

### Additional Notes:
<!-- Any other context about the PR. -->
